### PR TITLE
[feature/user-and-room] Room CRUD 로직 보강 및 Room Image CRUD 구현

### DIFF
--- a/src/main/java/com/sju/roomreservationbackend/common/base/media/FileMetadata.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/base/media/FileMetadata.java
@@ -21,16 +21,16 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public class FileMetadata {
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     protected FileType type;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     protected String fileName;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     protected String fileURL;
 
-    @Column(nullable = false)
+    @Column
     protected Long fileSize;
 
     @Column(nullable = false)

--- a/src/main/java/com/sju/roomreservationbackend/common/base/media/dto/request/UploadMediaReqDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/base/media/dto/request/UploadMediaReqDTO.java
@@ -11,12 +11,4 @@ import jakarta.validation.constraints.Size;
 public class UploadMediaReqDTO {
     @NotNull(message = "valid.media.media.file.null")
     protected MultipartFile file;
-
-    @NotBlank(message = "valid.media.author.blank")
-    @Size(max = 50, message = "valid.media.author.size")
-    protected String author;
-
-    @NotBlank(message = "valid.media.translator.blank")
-    @Size(max = 50, message = "valid.media.translator.size")
-    protected String translator;
 }

--- a/src/main/java/com/sju/roomreservationbackend/common/base/media/dto/request/UploadMultipleMediaReqDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/base/media/dto/request/UploadMultipleMediaReqDTO.java
@@ -1,13 +1,11 @@
 package com.sju.roomreservationbackend.common.base.media.dto.request;
 
 import com.sju.roomreservationbackend.common.http.GeneralResDTO;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Data
@@ -15,12 +13,4 @@ import java.util.List;
 public class UploadMultipleMediaReqDTO extends GeneralResDTO {
     @NotEmpty(message = "valid.media.file.empty")
     protected List<MultipartFile> files;
-
-    @NotBlank(message = "valid.media.author.blank")
-    @Size(max = 50, message = "valid.media.author.size")
-    protected String author;
-
-    @NotBlank(message = "valid.media.translator.blank")
-    @Size(max = 50, message = "valid.media.translator.size")
-    protected String translator;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/RoomImgAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/RoomImgAPI.java
@@ -18,20 +18,20 @@ public class RoomImgAPI {
     private final RoomImgCrudServ roomImgCrudServ;
 
     @PreAuthorize("hasAnyAuthority('ADMIN','ROOT_ADMIN')")
-    @PostMapping("/musics")
+    @PostMapping("/rooms/images")
     ResponseEntity<?> uploadMusic(@Valid UploadRoomImgReqDTO reqDTO) {
         UploadRoomImgResDTO resDTO = new UploadRoomImgResDTO();
 
         return new APIUtil<UploadRoomImgResDTO>() {
             @Override
             protected void onSuccess() throws Exception {
-                resDTO.setUploadedRoomImage(roomImgCrudServ.createRoomImg(reqDTO));
+                resDTO.setUploadedRoomImages(roomImgCrudServ.createRoomImg(reqDTO));
             }
         }.execute(resDTO, "res.room.image.upload.success");
     }
 
     @PreAuthorize("hasAnyAuthority('ADMIN','ROOT_ADMIN')")
-    @DeleteMapping("/musics")
+    @DeleteMapping("/rooms/images")
     ResponseEntity<?> deleteMusic(@Valid DeleteRoomImgReqDto reqDTO) {
         DeleteRoomImgResDto resDTO = new DeleteRoomImgResDto();
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/RoomImgAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/RoomImgAPI.java
@@ -1,4 +1,45 @@
 package com.sju.roomreservationbackend.domain.room.detail;
 
+import com.sju.roomreservationbackend.common.http.APIUtil;
+import com.sju.roomreservationbackend.domain.room.detail.dto.request.DeleteRoomImgReqDto;
+import com.sju.roomreservationbackend.domain.room.detail.dto.request.UploadRoomImgReqDTO;
+import com.sju.roomreservationbackend.domain.room.detail.dto.response.DeleteRoomImgResDto;
+import com.sju.roomreservationbackend.domain.room.detail.dto.response.UploadRoomImgResDTO;
+import com.sju.roomreservationbackend.domain.room.detail.service.RoomImgCrudServ;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
 public class RoomImgAPI {
+    private final RoomImgCrudServ roomImgCrudServ;
+
+    @PreAuthorize("hasAnyAuthority('ADMIN','ROOT_ADMIN')")
+    @PostMapping("/musics")
+    ResponseEntity<?> uploadMusic(@Valid UploadRoomImgReqDTO reqDTO) {
+        UploadRoomImgResDTO resDTO = new UploadRoomImgResDTO();
+
+        return new APIUtil<UploadRoomImgResDTO>() {
+            @Override
+            protected void onSuccess() throws Exception {
+                resDTO.setUploadedRoomImage(roomImgCrudServ.createRoomImg(reqDTO));
+            }
+        }.execute(resDTO, "res.room.image.upload.success");
+    }
+
+    @PreAuthorize("hasAnyAuthority('ADMIN','ROOT_ADMIN')")
+    @DeleteMapping("/musics")
+    ResponseEntity<?> deleteMusic(@Valid DeleteRoomImgReqDto reqDTO) {
+        DeleteRoomImgResDto resDTO = new DeleteRoomImgResDto();
+
+        return new APIUtil<DeleteRoomImgResDto>() {
+            @Override
+            protected void onSuccess() throws Exception {
+                resDTO.setDeleteRoomImgId(roomImgCrudServ.deleteRoomImg(reqDTO.getId()));
+            }
+        }.execute(resDTO, "res.room.image.delete.success");
+    }
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/DeleteRoomImgReqDto.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/DeleteRoomImgReqDto.java
@@ -1,11 +1,15 @@
 package com.sju.roomreservationbackend.domain.room.detail.dto.request;
 
 import com.sju.roomreservationbackend.common.base.media.dto.request.DeleteMediaReqDTO;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class DeleteRoomImgReqDto extends DeleteMediaReqDTO {
+    @NotNull(message = "valid.room.image.id.null")
+    @PositiveOrZero(message = "valid.room.image.id.positive")
     private Long id;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/UploadRoomImgReqDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/UploadRoomImgReqDTO.java
@@ -1,11 +1,15 @@
 package com.sju.roomreservationbackend.domain.room.detail.dto.request;
 
 import com.sju.roomreservationbackend.common.base.media.dto.request.UploadMediaReqDTO;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class UploadRoomImgReqDTO extends UploadMediaReqDTO {
+    @NotNull(message = "valid.room.id.null")
+    @PositiveOrZero(message = "valid.room.id.positive")
     private Long roomId;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/UploadRoomImgReqDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/request/UploadRoomImgReqDTO.java
@@ -1,6 +1,6 @@
 package com.sju.roomreservationbackend.domain.room.detail.dto.request;
 
-import com.sju.roomreservationbackend.common.base.media.dto.request.UploadMediaReqDTO;
+import com.sju.roomreservationbackend.common.base.media.dto.request.UploadMultipleMediaReqDTO;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
@@ -8,7 +8,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class UploadRoomImgReqDTO extends UploadMediaReqDTO {
+public class UploadRoomImgReqDTO extends UploadMultipleMediaReqDTO {
     @NotNull(message = "valid.room.id.null")
     @PositiveOrZero(message = "valid.room.id.positive")
     private Long roomId;

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/DeleteRoomImgResDto.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/DeleteRoomImgResDto.java
@@ -1,4 +1,11 @@
 package com.sju.roomreservationbackend.domain.room.detail.dto.response;
 
-public class DeleteRoomImgResDto {
+import com.sju.roomreservationbackend.common.http.GeneralResDTO;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DeleteRoomImgResDto extends GeneralResDTO {
+    private Long deleteRoomImgId;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/UploadRoomImgResDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/UploadRoomImgResDTO.java
@@ -1,4 +1,12 @@
 package com.sju.roomreservationbackend.domain.room.detail.dto.response;
 
-public class UploadRoomImgResDTO {
+import com.sju.roomreservationbackend.common.http.GeneralResDTO;
+import com.sju.roomreservationbackend.domain.room.detail.entity.RoomImage;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class UploadRoomImgResDTO extends GeneralResDTO {
+    private RoomImage uploadedRoomImage;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/UploadRoomImgResDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/dto/response/UploadRoomImgResDTO.java
@@ -5,8 +5,10 @@ import com.sju.roomreservationbackend.domain.room.detail.entity.RoomImage;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.List;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class UploadRoomImgResDTO extends GeneralResDTO {
-    private RoomImage uploadedRoomImage;
+    private List<RoomImage> uploadedRoomImages;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/entity/RoomImage.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/entity/RoomImage.java
@@ -1,14 +1,27 @@
 package com.sju.roomreservationbackend.domain.room.detail.entity;
 
+import com.sju.roomreservationbackend.common.base.media.FileMetadata;
 import com.sju.roomreservationbackend.domain.room.profile.entity.Room;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
-
-public class RoomImage {
+@Entity
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoomImage extends FileMetadata {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_img_id")
     private Long id;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH}, fetch = FetchType.EAGER, targetEntity = Room.class)
+    @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     private Room room;
-    private String fileName;
-    private String fileSize;
-    private String fileUrl;
-    private LocalDateTime timestamp;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/repository/RoomImgRepo.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/repository/RoomImgRepo.java
@@ -1,4 +1,9 @@
 package com.sju.roomreservationbackend.domain.room.detail.repository;
 
-public interface RoomImgRepo {
+import com.sju.roomreservationbackend.domain.room.detail.entity.RoomImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomImgRepo extends JpaRepository<RoomImage, Long> {
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
@@ -1,4 +1,50 @@
 package com.sju.roomreservationbackend.domain.room.detail.service;
 
-public class RoomImgCrudServ {
+import com.sju.roomreservationbackend.common.base.media.FileMetadata;
+import com.sju.roomreservationbackend.common.storage.FileType;
+import com.sju.roomreservationbackend.common.storage.StorageService;
+import com.sju.roomreservationbackend.domain.room.detail.dto.request.UploadRoomImgReqDTO;
+import com.sju.roomreservationbackend.domain.room.detail.entity.RoomImage;
+import com.sju.roomreservationbackend.domain.room.detail.repository.RoomImgRepo;
+import com.sju.roomreservationbackend.domain.room.profile.repository.RoomRepo;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+@Service
+public class RoomImgCrudServ extends RoomImgLogicServ{
+
+    public RoomImgCrudServ(RoomImgRepo roomImgRepo, RoomRepo roomRepo, StorageService storageServ) {
+        super(roomImgRepo, roomRepo, storageServ);
+    }
+
+    @Transactional
+    public RoomImage createRoomImg(UploadRoomImgReqDTO reqDTO) throws Exception {
+        MultipartFile file = reqDTO.getFile();
+        FileMetadata metadata = this.storageServ.saveFile(file, FileType.MEDIA_PHOTO, "room", reqDTO.getRoomId());
+
+        RoomImage roomImg = RoomImage.builder()
+                .room(this.fetchRoomById(reqDTO.getRoomId()))
+                .type(metadata.getType())
+                .fileName(metadata.getFileName())
+                .fileSize(metadata.getFileSize())
+                .fileURL(metadata.getFileURL())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return roomImgRepo.save(roomImg);
+    }
+
+    @Transactional
+    public Long deleteRoomImg(Long roomImgId) throws Exception {
+        RoomImage target = roomImgRepo.findById(roomImgId).orElseThrow(
+                () -> new Exception(msgSrc.getMessage("error.room.image.notExist", null, Locale.ENGLISH))
+        );
+
+        storageServ.deleteFile(target.getFileURL());
+        roomImgRepo.delete(target);
+        return target.getId();
+    }
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 @Service
@@ -22,12 +24,21 @@ public class RoomImgCrudServ extends RoomImgLogicServ{
     }
 
     @Transactional
-    public RoomImage createRoomImg(UploadRoomImgReqDTO reqDTO) throws Exception {
-        MultipartFile file = reqDTO.getFile();
-        FileMetadata metadata = this.storageServ.saveFile(file, FileType.MEDIA_PHOTO, "room", reqDTO.getRoomId());
+    public List<RoomImage> createRoomImg(UploadRoomImgReqDTO reqDTO) throws Exception {
+        List<RoomImage> images = new ArrayList<>();
+
+        for (MultipartFile file : reqDTO.getFiles()) {
+            images.add(this.createRoomImg(reqDTO.getRoomId(), file));
+        }
+        return images;
+    }
+
+    @Transactional
+    public RoomImage createRoomImg(Long roomId, MultipartFile file) throws Exception {
+        FileMetadata metadata = this.storageServ.saveFile(file, FileType.MEDIA_PHOTO, "room", roomId);
 
         RoomImage roomImg = RoomImage.builder()
-                .room(this.fetchRoomById(reqDTO.getRoomId()))
+                .room(this.fetchRoomById(roomId))
                 .type(metadata.getType())
                 .fileName(metadata.getFileName())
                 .fileSize(metadata.getFileSize())

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgLogicServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgLogicServ.java
@@ -1,4 +1,20 @@
 package com.sju.roomreservationbackend.domain.room.detail.service;
 
-public class RoomImgLogicServ {
+import com.sju.roomreservationbackend.common.message.MessageConfig;
+import com.sju.roomreservationbackend.common.storage.StorageService;
+import com.sju.roomreservationbackend.domain.room.detail.repository.RoomImgRepo;
+import com.sju.roomreservationbackend.domain.room.profile.repository.RoomRepo;
+import com.sju.roomreservationbackend.domain.room.profile.services.RoomCrudServ;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoomImgLogicServ extends RoomCrudServ {
+    protected RoomImgRepo roomImgRepo;
+    protected static MessageSource msgSrc = MessageConfig.getRoomMsgSrc();
+
+    public RoomImgLogicServ(RoomImgRepo roomImgRepo, RoomRepo roomRepo, StorageService storageServ) {
+        super(roomRepo, storageServ);
+        this.roomImgRepo = roomImgRepo;
+    }
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
@@ -27,7 +27,7 @@ public class RoomAPI {
 
         return new APIUtil<CreateRoomResDTO>() {
             @Override
-            protected void onSuccess() {
+            protected void onSuccess() throws Exception {
                 resDTO.setCreatedRoomProfile(roomCrudServ.createRoom(reqDTO));
             }
         }.execute(resDTO, "res.room.create.success");

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
@@ -34,7 +34,7 @@ public class RoomAPI {
     }
 
     @GetMapping("/rooms/profiles")
-    public ResponseEntity<?> fetchRoom(@RequestBody @Valid FetchRoomReqDTO reqDTO, @RequestHeader("Request-Type") String reqType) {
+    public ResponseEntity<?> fetchRoom(@Valid FetchRoomReqDTO reqDTO, @RequestHeader("Request-Type") String reqType) {
         FetchRoomReqOptionType reqOptionType = FetchRoomReqOptionType.valueOf(reqType);
         FetchRoomResDTO resDTO = new FetchRoomResDTO();
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/repository/RoomRepo.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/repository/RoomRepo.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface RoomRepo extends JpaRepository<Room, Long> {
     Boolean existsByName(String name);
-    List<Room> findAllByNameLike(String name);
+    Boolean existsByBuildingAndNumber(String building, Integer number);
+    List<Room> findAllByNameContainingIgnoreCase(String name);
     Page<Room> findAllByBuilding(String building, Pageable pageable);
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/repository/RoomRepo.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/repository/RoomRepo.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface RoomRepo extends JpaRepository<Room, Long> {
+    Boolean existsByName(String name);
     List<Room> findAllByNameLike(String name);
     Page<Room> findAllByBuilding(String building, Pageable pageable);
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomCrudServ.java
@@ -27,6 +27,7 @@ public class RoomCrudServ extends RoomLogicServ {
         
         // 명칭 중복 체크
         this.checkNameDuplication(reqDTO.getName());
+        this.checkBuildingAndNumberDuplication(reqDTO.getBuilding(), reqDTO.getNumber());
 
         Room room = Room.builder()
                 .name(reqDTO.getName())
@@ -58,7 +59,7 @@ public class RoomCrudServ extends RoomLogicServ {
     }
 
     public List<Room> fetchRoomsByName(String name) {
-        return roomRepo.findAllByNameLike(name);
+        return roomRepo.findAllByNameContainingIgnoreCase(name);
     }
 
     public Page<Room> fetchRoomsByBuilding(String building, int pageIdx, int pageLimit) {
@@ -67,6 +68,8 @@ public class RoomCrudServ extends RoomLogicServ {
 
     @Transactional
     public Room updateRoom(UpdateRoomReqDTO reqDTO) throws Exception {
+        this.checkNameDuplication(reqDTO.getName());
+
         Room room = this.fetchRoomById(reqDTO.getId());
 
         room.setName(reqDTO.getName() == null ? room.getName() : reqDTO.getName());

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomLogicServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomLogicServ.java
@@ -7,13 +7,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 
+import java.util.Locale;
+
 @RequiredArgsConstructor
 @Service
 public class RoomLogicServ {
     protected final RoomRepo roomRepo;
     protected final MessageSource msgSrc = MessageConfig.getRoomMsgSrc();
 
-    protected void checkRoomIsValid(Room room) throws Exception {
-
+    protected void checkNameDuplication(String name) throws Exception {
+        if (roomRepo.existsByName(name)) {
+            throw new Exception(msgSrc.getMessage("error.room.name.dup", null, Locale.ENGLISH));
+        }
     }
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomLogicServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/services/RoomLogicServ.java
@@ -20,4 +20,9 @@ public class RoomLogicServ {
             throw new Exception(msgSrc.getMessage("error.room.name.dup", null, Locale.ENGLISH));
         }
     }
+    protected void checkBuildingAndNumberDuplication(String building, Integer number) throws Exception {
+        if (roomRepo.existsByBuildingAndNumber(building,number)) {
+            throw new Exception(msgSrc.getMessage("error.room.building.dup", null, Locale.ENGLISH));
+        }
+    }
 }

--- a/src/main/resources/application-dev-newcentury99-desktop.properties
+++ b/src/main/resources/application-dev-newcentury99-desktop.properties
@@ -1,0 +1,17 @@
+# Environment Variables - For Development Environment of NewCentury99
+
+# Spring Boot Config
+server.port=3000
+spring.devtools.livereload.enabled=true
+
+# MySQL Config
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/capstone?characterEncoding=UTF-8
+spring.datasource.username=capstone
+spring.datasource.password=password
+
+# Static File Path Config
+storage.rootPath=E:\\Capstone_Storage
+spring.mvc.static-path-pattern=/storage/**
+spring.web.resources.static-locations=file:///E:/Capstone_Storage
+

--- a/src/main/resources/application-dev-newcentury99-desktop.properties
+++ b/src/main/resources/application-dev-newcentury99-desktop.properties
@@ -11,7 +11,7 @@ spring.datasource.username=capstone
 spring.datasource.password=password
 
 # Static File Path Config
-storage.rootPath=E:\\Capstone_Storage
+storage.rootPath=E:\\SJU_Capstone_Storage
 spring.mvc.static-path-pattern=/storage/**
-spring.web.resources.static-locations=file:///E:/Capstone_Storage
+spring.web.resources.static-locations=file:///E:/SJU_Capstone_Storage
 

--- a/src/main/resources/messages/rooms/error.properties
+++ b/src/main/resources/messages/rooms/error.properties
@@ -1,3 +1,4 @@
 error.room.notExist=Room not exists
 error.room.name.dup=Room name already registered
+error.room.building.dup=Room building and number are already registered
 error.room.image.notExist=Room image not exists

--- a/src/main/resources/messages/rooms/error.properties
+++ b/src/main/resources/messages/rooms/error.properties
@@ -1,0 +1,3 @@
+error.room.notExist=Room not exists
+error.room.name.dup=Room name already registered
+error.room.image.notExist=Room image not exists

--- a/src/main/resources/messages/rooms/response.properties
+++ b/src/main/resources/messages/rooms/response.properties
@@ -1,2 +1,7 @@
 res.room.create.success=Room created successfully
 res.room.fetch.success=Room fetched successfully
+res.room.update.success=Room updated successfully
+res.room.delete.success=Room deleted successfully
+
+res.room.image.upload.success=Room image upload successfully
+res.room.image.delete.success=Room image delete successfully

--- a/src/main/resources/messages/rooms/validation.properties
+++ b/src/main/resources/messages/rooms/validation.properties
@@ -1,0 +1,13 @@
+valid.room.id.null=Null room id not allowed
+valid.room.id.positive=Room id must be positive value
+valid.room.name.blank=Blank room name not allowed
+valid.room.name.size=Room name must be shorter then {0} characters
+valid.room.number.null=Null room number not allowed
+valid.room.description.size=Room description must be shorter then {0} characters
+valid.room.capacity.null=Null room capacity not allowed
+valid.room.whiteboard.null=Null room whiteboard not allowed
+valid.room.projector.null=Null room projector not allowed
+valid.room.time.null=Null room max time limit not allowed
+valid.room.time.size=Room max time limit must be in range {1} ~ {0} hours
+valid.room.image.id.null=Null room image id not allowed
+valid.room.image.id.positive=Room image id must be positive value


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
Room CRUD시 입력값 중복 등 검증 로직 추가
Room Image 업로드/삭제 기능 추가
Room 생성/삭제시 저장공간 생성/삭제 연동 기능 추가

## 변경사항
 * RoomCurdServ 개선
 * RoomLogicServ 구현
 * RoomImgCrudServ 구현
 * RoomImgLogicServ 구현
 * RoomImg의 Req/Res DTO 구현
 * RoomImg의 Repository 정의
 * Room 엔티티의 validation, response, error message 추가
 
## 비고
postman 문서화 완료 (성공+실패 케이스 포함)
**room_image 테이블의 FK의 경우 서버 기동 후 DB툴에서 update cascade, delete cascade 설정 필수**
(설정 안할시 room_image가 있는 room 재귀삭제 불가)

GET/DELETE 엔드포인트의 경우 의도적으로 @RequestBody를 제거하였습니다
GET과 DELETE는 Resful API 표준규약상 Body를 포함할 수 없습니다.
포스트맨에서는 Params 탭에서 파라미터를 넣으시면 됩니다. (Room 예시 참고)
GET/DELETE 특성상 파라미터는 주소창에 인코딩 되어 들어갑니다. (HTTP 표준규격)

## 품질 관리를 위한 체크리스트
 - [ ] 해당사항 없음 (**소스코드 수정을 하지 않았습니다.**)
### 소스코드 테스트
**세 가지 테스트 모두를 실시하는 것을 권장하며, 최소한 작동확인(수동 테스트)은 해보셔야 합니다.**
 - [x] 수동 테스트 / Manual Test (앱 구동후 사용확인을 통한 직접 테스트 또는 서버 구동후 Postman을 이용한 테스트)
### 기본 확인사항
 - [x] IDE에서 검출되는 모든 경고와 오류를 해결하셨습니까?
 - [x] 코딩 컨벤션(-추후 문서화 예정- 작명법, 금기사항, 구현방식 등)을 준수하셨습니까?
 - [x] 버그 또는 구현상의 실수, 누락 등 하자사항이 없는지 테스트하여 확인해보셨습니까?
 - [x] 명칭(변수명, 함수명, 주석 등)에 오타가 있는지 테스트하여 확인해보셨습니까?
 - [x] 이번 변경사항에 포함된 주석 및 기능 명세, 관련 문서를 최신화하셨습니까?
