### PR TITLE
[hotfix/device] Add checkInCode Send to device logic

### DIFF
--- a/firmware/newcentury_env.ino
+++ b/firmware/newcentury_env.ino
@@ -71,16 +71,16 @@ void loop() {
 
         if (data.empty) {
           u8g2.setCursor(0, 44);
-          u8g2.print("예약자: " + data.revOwnerName);
-
-          u8g2.setCursor(0, 60);
-          u8g2.print("인증No: " + data.checkInCode);
-        } else {
-          u8g2.setCursor(0, 44);
           u8g2.print("예약 정보 없음");
 
           u8g2.setCursor(0, 60);
           u8g2.print("(공실입니다)");
+        } else {
+          u8g2.setCursor(0, 44);
+          u8g2.print("예약자: " + data.revOwnerName);
+
+          u8g2.setCursor(0, 60);
+          u8g2.print("인증No: " + data.checkInCode);
         }
       } else {
         u8g2.setFont(u8g2_font_squeezed_r6_tr);

--- a/firmware/newcentury_env.ino
+++ b/firmware/newcentury_env.ino
@@ -8,7 +8,7 @@
 // for SPI
 #include <SPI.h>
 
-char* ssid = "NewCentury";    //wift 아이디
+char* ssid = "NewCentury";    //wifi 아이디
 char* password =  "**-*******";    // wifi 비번
 char* serverName = "http://211.180.114.56/api/rooms/profiles/devices?id=9"; // 웹서버주소 (id 다음에 룸 넘버 설정)
 

--- a/firmware/newcentury_env.ino
+++ b/firmware/newcentury_env.ino
@@ -1,0 +1,156 @@
+#include <Arduino.h>
+#include <U8g2lib.h>
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <HttpClient.h>
+
+// for SPI
+#include <SPI.h>
+
+char* ssid = "NewCentury";    //wift 아이디
+char* password =  "**-*******";    // wifi 비번
+char* serverName = "http://211.180.114.56/api/rooms/profiles/devices?id=9"; // 웹서버주소 (id 다음에 룸 넘버 설정)
+
+WiFiClient client;
+
+typedef struct RevData {
+  int status = 0;
+  String building = "";
+  String number = "";
+  String revOwnerName = "";
+  String checkInCode = "";
+  bool empty = true;
+};
+
+RevData req_data();
+void printSerialLog(RevData parsedData);
+
+
+// for using Korean NanumGothicCoding font
+//#include "u8g2_font_unifont_t_korean_NanumGothicCoding_16.h"
+U8G2_SH1106_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0, /* cs=*/ 5, /* dc=*/ 14, /* reset=*/ 15);
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);   // 와이파이 접속
+  u8g2.begin();
+  u8g2.enableUTF8Print();   // enable UTF8 support for the Arduino print() function
+}
+
+void loop() {
+  u8g2.firstPage();
+  do {
+
+    if (WiFi.status() != WL_CONNECTED) { //Check for the connection
+      Serial.println("Connecting to WiFi..");
+      u8g2.setFont(u8g2_font_squeezed_r6_tr);
+      u8g2.setCursor(0, 10);
+      u8g2.print("Sejong Conference Room Reservation");
+
+      u8g2.setCursor(0, 20);
+      u8g2.print("SSID: ");
+      u8g2.setCursor(20, 20);
+      u8g2.print(ssid);
+
+      u8g2.setFont(u8g2_font_unifont_t_korean2);
+      u8g2.setCursor(0, 36);
+      u8g2.print("WIFI 접속 중...");
+    } else {
+      Serial.println("Connected to the WiFi network");
+      RevData data = req_data();
+      if (data.status) {
+        u8g2.setFont(u8g2_font_squeezed_r6_tr);
+        u8g2.setCursor(0, 10);
+        u8g2.print("Sejong Conference Room Reservation");
+
+        u8g2.setFont(u8g2_font_unifont_t_korean2);
+
+        u8g2.setCursor(0, 26);
+        u8g2.print(data.building + " " + data.number);
+
+        if (data.empty) {
+          u8g2.setCursor(0, 44);
+          u8g2.print("예약자: " + data.revOwnerName);
+
+          u8g2.setCursor(0, 60);
+          u8g2.print("인증No: " + data.checkInCode);
+        } else {
+          u8g2.setCursor(0, 44);
+          u8g2.print("예약 정보 없음");
+
+          u8g2.setCursor(0, 60);
+          u8g2.print("(공실입니다)");
+        }
+      } else {
+        u8g2.setFont(u8g2_font_squeezed_r6_tr);
+        u8g2.setCursor(0, 10);
+        u8g2.print("Sejong Conference Room Reservation");
+
+        u8g2.setFont(u8g2_font_unifont_t_korean2);
+
+        u8g2.setCursor(0, 26);
+        u8g2.print("HTTP 통신 에러");
+      }
+
+      // u8g2.print(name.c_str());  // write something to the internal memory
+    }
+  } while (u8g2.nextPage());
+  delay(5000);
+}
+
+RevData req_data() {
+  HTTPClient http;
+  http.begin(serverName);
+  int httpCode = http.GET();
+  String payload = "";
+  RevData parsedData;
+
+  if (httpCode > 0) {
+    payload = http.getString();
+
+    StaticJsonDocument<5000> jsonDoc; //Memory pool
+    DeserializationError err = deserializeJson(jsonDoc, payload);
+
+    if (err) {
+      Serial.print(F("deserializeJson() failed with code "));
+      Serial.println(err.f_str());
+    }
+    Serial.println("Receieved:");
+    Serial.println(payload);
+
+    int status = jsonDoc["_metadata"]["status"];
+    if (status) {
+      parsedData.status = jsonDoc["_metadata"]["status"];
+      const char* building = jsonDoc["room"]["building"];
+      int number = jsonDoc["room"]["number"];
+      parsedData.building = building;
+      parsedData.number = String(number);
+      parsedData.empty = jsonDoc["currentRev"].isNull();
+      if (parsedData.empty) {
+        parsedData.revOwnerName = "";
+        parsedData.checkInCode = "";
+      } else {
+        const char* name = jsonDoc["currentRev"]["revOwner"]["name"];
+        parsedData.revOwnerName = name;
+        const char* code = jsonDoc["code"];
+        parsedData.checkInCode = code;
+      }
+    }
+    printSerialLog(parsedData);
+  } else {
+    Serial.println("Error on HTTP Request");
+    Serial.printf("[HTTP] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
+  }
+  http.end();
+  return parsedData;
+}
+
+void printSerialLog(RevData parsedData) {
+  Serial.println("Result: ");
+  Serial.println("building: " + parsedData.building);
+  Serial.println("number: " + parsedData.number);
+  Serial.println("empty: " + String(parsedData.empty));
+  Serial.println("name: " + parsedData.revOwnerName);
+  Serial.println("checkInCode: " + parsedData.checkInCode);
+}

--- a/firmware/sejong_env_via_newcentury_vpn.ino
+++ b/firmware/sejong_env_via_newcentury_vpn.ino
@@ -8,7 +8,7 @@
 // for SPI
 #include <SPI.h>
 
-char* ssid = "NewCentury";    //wift 아이디
+char* ssid = "NewCenturyVPN";    //wifi 아이디
 char* password =  "**-*******";    // wifi 비번
 char* serverName = "http://211.180.114.56/api/rooms/profiles/devices?id=9"; // 웹서버주소 (id 다음에 룸 넘버 설정)
 

--- a/firmware/sejong_env_via_newcentury_vpn.ino
+++ b/firmware/sejong_env_via_newcentury_vpn.ino
@@ -1,0 +1,156 @@
+#include <Arduino.h>
+#include <U8g2lib.h>
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <HttpClient.h>
+
+// for SPI
+#include <SPI.h>
+
+char* ssid = "NewCentury";    //wift 아이디
+char* password =  "**-*******";    // wifi 비번
+char* serverName = "http://211.180.114.56/api/rooms/profiles/devices?id=9"; // 웹서버주소 (id 다음에 룸 넘버 설정)
+
+WiFiClient client;
+
+typedef struct RevData {
+  int status = 0;
+  String building = "";
+  String number = "";
+  String revOwnerName = "";
+  String checkInCode = "";
+  bool empty = true;
+};
+
+RevData req_data();
+void printSerialLog(RevData parsedData);
+
+
+// for using Korean NanumGothicCoding font
+//#include "u8g2_font_unifont_t_korean_NanumGothicCoding_16.h"
+U8G2_SH1106_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0, /* cs=*/ 5, /* dc=*/ 14, /* reset=*/ 15);
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);   // 와이파이 접속
+  u8g2.begin();
+  u8g2.enableUTF8Print();   // enable UTF8 support for the Arduino print() function
+}
+
+void loop() {
+  u8g2.firstPage();
+  do {
+
+    if (WiFi.status() != WL_CONNECTED) { //Check for the connection
+      Serial.println("Connecting to WiFi..");
+      u8g2.setFont(u8g2_font_squeezed_r6_tr);
+      u8g2.setCursor(0, 10);
+      u8g2.print("Sejong Conference Room Reservation");
+
+      u8g2.setCursor(0, 20);
+      u8g2.print("SSID: ");
+      u8g2.setCursor(20, 20);
+      u8g2.print(ssid);
+
+      u8g2.setFont(u8g2_font_unifont_t_korean2);
+      u8g2.setCursor(0, 36);
+      u8g2.print("WIFI 접속 중...");
+    } else {
+      Serial.println("Connected to the WiFi network");
+      RevData data = req_data();
+      if (data.status) {
+        u8g2.setFont(u8g2_font_squeezed_r6_tr);
+        u8g2.setCursor(0, 10);
+        u8g2.print("Sejong Conference Room Reservation");
+
+        u8g2.setFont(u8g2_font_unifont_t_korean2);
+
+        u8g2.setCursor(0, 26);
+        u8g2.print(data.building + " " + data.number);
+
+        if (data.empty) {
+          u8g2.setCursor(0, 44);
+          u8g2.print("예약 정보 없음");
+
+          u8g2.setCursor(0, 60);
+          u8g2.print("(공실입니다)");
+        } else {
+          u8g2.setCursor(0, 44);
+          u8g2.print("예약자: " + data.revOwnerName);
+
+          u8g2.setCursor(0, 60);
+          u8g2.print("인증No: " + data.checkInCode);
+        }
+      } else {
+        u8g2.setFont(u8g2_font_squeezed_r6_tr);
+        u8g2.setCursor(0, 10);
+        u8g2.print("Sejong Conference Room Reservation");
+
+        u8g2.setFont(u8g2_font_unifont_t_korean2);
+
+        u8g2.setCursor(0, 26);
+        u8g2.print("HTTP 통신 에러");
+      }
+
+      // u8g2.print(name.c_str());  // write something to the internal memory
+    }
+  } while (u8g2.nextPage());
+  delay(5000);
+}
+
+RevData req_data() {
+  HTTPClient http;
+  http.begin(serverName);
+  int httpCode = http.GET();
+  String payload = "";
+  RevData parsedData;
+
+  if (httpCode > 0) {
+    payload = http.getString();
+
+    StaticJsonDocument<5000> jsonDoc; //Memory pool
+    DeserializationError err = deserializeJson(jsonDoc, payload);
+
+    if (err) {
+      Serial.print(F("deserializeJson() failed with code "));
+      Serial.println(err.f_str());
+    }
+    Serial.println("Receieved:");
+    Serial.println(payload);
+
+    int status = jsonDoc["_metadata"]["status"];
+    if (status) {
+      parsedData.status = jsonDoc["_metadata"]["status"];
+      const char* building = jsonDoc["room"]["building"];
+      int number = jsonDoc["room"]["number"];
+      parsedData.building = building;
+      parsedData.number = String(number);
+      parsedData.empty = jsonDoc["currentRev"].isNull();
+      if (parsedData.empty) {
+        parsedData.revOwnerName = "";
+        parsedData.checkInCode = "";
+      } else {
+        const char* name = jsonDoc["currentRev"]["revOwner"]["name"];
+        parsedData.revOwnerName = name;
+        const char* code = jsonDoc["code"];
+        parsedData.checkInCode = code;
+      }
+    }
+    printSerialLog(parsedData);
+  } else {
+    Serial.println("Error on HTTP Request");
+    Serial.printf("[HTTP] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
+  }
+  http.end();
+  return parsedData;
+}
+
+void printSerialLog(RevData parsedData) {
+  Serial.println("Result: ");
+  Serial.println("building: " + parsedData.building);
+  Serial.println("number: " + parsedData.number);
+  Serial.println("empty: " + String(parsedData.empty));
+  Serial.println("name: " + parsedData.revOwnerName);
+  Serial.println("checkInCode: " + parsedData.checkInCode);
+}

--- a/src/main/java/com/sju/roomreservationbackend/common/email/verification/repository/EmailVerifyRepoImpl.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/email/verification/repository/EmailVerifyRepoImpl.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static com.sju.roomreservationbackend.common.email.verification.entity.QEmailVerifyLog.emailVerifyLog;
 
@@ -17,7 +18,7 @@ public class EmailVerifyRepoImpl implements EmailVerifyDslRepo {
     @Override
     public void deleteExpiredLog() {
         queryFactory.delete(emailVerifyLog)
-                .where(emailVerifyLog.verified.isFalse().and(emailVerifyLog.validUntil.before(LocalDateTime.now())))
+                .where(emailVerifyLog.verified.isFalse().and(emailVerifyLog.validUntil.before(LocalDateTime.now(ZoneId.of("Asia/Seoul")))))
                 .execute();
     }
 }

--- a/src/main/java/com/sju/roomreservationbackend/common/email/verification/services/EmailVerifyServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/email/verification/services/EmailVerifyServ.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 @Service
@@ -25,7 +26,7 @@ public class EmailVerifyServ implements EmailVerifyServObservable {
         emailVerifyRepo.findByEmail(email).ifPresent(this.emailVerifyRepo::delete);
 
         // 이메일 인증번호 만료시간 산출
-        LocalDateTime expiredTime = LocalDateTime.now().plus(10, ChronoUnit.MINUTES);
+        LocalDateTime expiredTime = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plus(10, ChronoUnit.MINUTES);
 
         // 이메일 인증요청 리스트에 추가
         EmailVerifyLog log = EmailVerifyLog.builder()
@@ -43,7 +44,7 @@ public class EmailVerifyServ implements EmailVerifyServObservable {
     public boolean checkAuthCode(String email, String authCode) {
         // 이메일 인증코드 검사
         EmailVerifyLog log = this.emailVerifyRepo.findByEmailAndVerifiedIsFalse(email).orElse(null);
-        boolean checkResult = log != null && log.getCode().equals(authCode) && LocalDateTime.now().isBefore(log.getValidUntil());
+        boolean checkResult = log != null && log.getCode().equals(authCode) && LocalDateTime.now(ZoneId.of("Asia/Seoul")).isBefore(log.getValidUntil());
         if (log != null) {
             log.setVerified(checkResult);
         }

--- a/src/main/java/com/sju/roomreservationbackend/common/security/JWTTokenProvider.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/security/JWTTokenProvider.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
@@ -110,7 +111,7 @@ public class JWTTokenProvider {
 
         // DB에 저장한 토큰 비교
         RefreshToken refreshToken = refreshTokenRepo.findByUsernameAndLoggedOutAndExpiredAtGreaterThan(
-                profile.getUsername(), false, LocalDateTime.now()
+                profile.getUsername(), false, LocalDateTime.now(ZoneId.of("Asia/Seoul"))
         ).orElse(null);
 
         // 리프레시 토큰 존재 여부 & 로그아웃 여부 & 토큰값 일치 검사

--- a/src/main/java/com/sju/roomreservationbackend/common/storage/StorageService.java
+++ b/src/main/java/com/sju/roomreservationbackend/common/storage/StorageService.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 @Service
@@ -167,7 +168,7 @@ public class StorageService {
                 .fileName(savePath.getFileName().toString())
                 .fileURL("/storage" + savePath.toString().replace(this.storageRootPath, "").replace("\\", "/"))
                 .fileSize(fileSize)
-                .timestamp(LocalDateTime.now())
+                .timestamp(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
     }
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/repository/ReservationRepoImpl.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/repository/ReservationRepoImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 
 import static com.sju.roomreservationbackend.domain.reservation.profile.entity.QReservation.reservation;
 
@@ -17,8 +18,8 @@ public class ReservationRepoImpl implements ReservationDslRepo{
 
     @Override
     public Reservation fetchCurrentReservationByRoomId(Long roomId) {
-        LocalDate currentDate = LocalDate.now();
-        LocalTime currentTime = LocalTime.now();
+        LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalTime currentTime = LocalTime.now(ZoneId.of("Asia/Seoul"));
         return queryFactory.select(reservation).from(reservation)
                 .where(reservation.room.id.eq(roomId)
                         .and(reservation.date.eq(currentDate))

--- a/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/NoShowCheckTask.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/NoShowCheckTask.java
@@ -14,6 +14,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class NoShowCheckTask implements Tasklet {
         // for each room
         for (Room room : rooms) {
             // get all reservations from previous day
-            List<Reservation> reservations = reservationCrudServ.fetchReservationsByRoomAndDate(room, LocalDate.now().minusDays(1));
+            List<Reservation> reservations = reservationCrudServ.fetchReservationsByRoomAndDate(room, LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1));
 
             // for each reservation
             for (Reservation reservation : reservations) {

--- a/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationCrudServ.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -202,7 +203,7 @@ public class ReservationCrudServ extends ReservationLogicServ {
     }
 
     private boolean reservationTimePassed(Reservation reservation) {
-        return LocalDate.now().isAfter(reservation.getDate()) || LocalTime.now().isAfter(reservation.getEnd());
+        return LocalDate.now(ZoneId.of("Asia/Seoul")).isAfter(reservation.getDate()) || LocalTime.now(ZoneId.of("Asia/Seoul")).isAfter(reservation.getEnd());
     }
 
     @Transactional

--- a/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationLogicServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationLogicServ.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Locale;
 
 @RequiredArgsConstructor
@@ -37,11 +38,11 @@ public class ReservationLogicServ {
         // 2. check if user is allowed to reserve at this point of date
         if(user.getPermissions().contains(Permission.GRADUATED)) {
             // if user is graduated, user can reserve up to 1-week period
-            return reservation.getDate().isBefore(LocalDate.now().plusDays(7));
+            return reservation.getDate().isBefore(LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(7));
         }
         if(user.getPermissions().contains(Permission.STUDENT)) {
             // if user is student, user can reserve before 2 days period
-            return reservation.getDate().isBefore(LocalDate.now().plusDays(2));
+            return reservation.getDate().isBefore(LocalDate.now(ZoneId.of("Asia/Seoul")).plusDays(2));
         }
 
         // 3. check room's state (max/normal/loose), and check if user is allowed to reserve
@@ -95,7 +96,7 @@ public class ReservationLogicServ {
     protected void checkIn(Reservation reservation, String checkInCode) {
         // check if reservation's date is same as today,
         // and check current time is between reservation's start and end time
-        if(!LocalDate.now().isEqual(reservation.getDate()) || !LocalTime.now().isAfter(reservation.getStart()) || !LocalTime.now().isBefore(reservation.getEnd())) {
+        if(!LocalDate.now(ZoneId.of("Asia/Seoul")).isEqual(reservation.getDate()) || !LocalTime.now(ZoneId.of("Asia/Seoul")).isAfter(reservation.getStart()) || !LocalTime.now(ZoneId.of("Asia/Seoul")).isBefore(reservation.getEnd())) {
             throw new IllegalArgumentException(reservationMsgSrc.getMessage("error.reservation.checkIn.expired", null, Locale.ENGLISH));
         }
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationNotificationSendTask.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/reservation/profile/service/ReservationNotificationSendTask.java
@@ -14,6 +14,7 @@ import org.springframework.batch.repeat.RepeatStatus;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class ReservationNotificationSendTask implements Tasklet {
         }
 
         // get reservation which date is today and reservation time range is [n] minutes later from now
-        List<Reservation> reservations = reservationCrudServ.fetchReservationByRoomAndDateAndTimeLeft(room, LocalDate.now(), LocalTime.now(), LocalTime.now().plusMinutes(minutes));
+        List<Reservation> reservations = reservationCrudServ.fetchReservationByRoomAndDateAndTimeLeft(room, LocalDate.now(ZoneId.of("Asia/Seoul")), LocalTime.now(ZoneId.of("Asia/Seoul")), LocalTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(minutes));
 
         for (Reservation reservation : reservations) {
             // for every attendant, get id

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/detail/service/RoomImgCrudServ.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -44,7 +45,7 @@ public class RoomImgCrudServ extends RoomImgLogicServ{
                 .fileName(metadata.getFileName())
                 .fileSize(metadata.getFileSize())
                 .fileURL(metadata.getFileURL())
-                .timestamp(LocalDateTime.now())
+                .timestamp(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
         return roomImgRepo.save(roomImg);
     }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
@@ -1,6 +1,7 @@
 package com.sju.roomreservationbackend.domain.room.profile;
 
 import com.sju.roomreservationbackend.common.http.APIUtil;
+import com.sju.roomreservationbackend.domain.reservation.profile.entity.Reservation;
 import com.sju.roomreservationbackend.domain.reservation.profile.service.ReservationCrudServ;
 import com.sju.roomreservationbackend.domain.room.detail.service.RoomImgCrudServ;
 import com.sju.roomreservationbackend.domain.room.profile.dto.request.*;
@@ -77,7 +78,9 @@ public class RoomAPI {
             @Override
             protected void onSuccess() throws Exception {
                 resDTO.setRoom(roomCrudServ.fetchRoomById(reqDTO.getId()));
-                resDTO.setCurrentRev(reservationCrudServ.fetchCurrentReservationByRoom(reqDTO.getId()));
+                Reservation reservation = reservationCrudServ.fetchCurrentReservationByRoom(reqDTO.getId());
+                resDTO.setCurrentRev(reservation);
+                resDTO.setCode(reservation.getCheckInCode());
             }
         }.execute(resDTO, "res.room.fetch.success");
     }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
@@ -78,9 +78,8 @@ public class RoomAPI {
             @Override
             protected void onSuccess() throws Exception {
                 resDTO.setRoom(roomCrudServ.fetchRoomById(reqDTO.getId()));
-                Reservation reservation = reservationCrudServ.fetchCurrentReservationByRoom(reqDTO.getId());
-                resDTO.setCurrentRev(reservation);
-                resDTO.setCode(reservation != null ? reservation.getCheckInCode() : null);
+                resDTO.setCurrentRev(reservationCrudServ.fetchCurrentReservationByRoom(reqDTO.getId()));
+                resDTO.setCode(resDTO.getCurrentRev() != null ? resDTO.getCurrentRev().getCheckInCode() : null);
             }
         }.execute(resDTO, "res.room.fetch.success");
     }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/RoomAPI.java
@@ -80,7 +80,7 @@ public class RoomAPI {
                 resDTO.setRoom(roomCrudServ.fetchRoomById(reqDTO.getId()));
                 Reservation reservation = reservationCrudServ.fetchCurrentReservationByRoom(reqDTO.getId());
                 resDTO.setCurrentRev(reservation);
-                resDTO.setCode(reservation.getCheckInCode());
+                resDTO.setCode(reservation != null ? reservation.getCheckInCode() : null);
             }
         }.execute(resDTO, "res.room.fetch.success");
     }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/profile/dto/response/FetchRoomForDeviceResDTO.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/profile/dto/response/FetchRoomForDeviceResDTO.java
@@ -13,4 +13,5 @@ import java.util.List;
 public class FetchRoomForDeviceResDTO extends GeneralPageableResDTO {
     private Room room;
     private Reservation currentRev;
+    private String code;
 }

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/stat/service/RoomLogServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/stat/service/RoomLogServ.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -43,8 +44,8 @@ public class RoomLogServ {
                 .room(room)
                 .user(revOwner)
                 .action(reserve)
-                .date(LocalDate.now())
-                .time(LocalTime.now())
+                .date(LocalDate.now(ZoneId.of("Asia/Seoul")))
+                .time(LocalTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
 
         roomLogRepo.save(roomLog);

--- a/src/main/java/com/sju/roomreservationbackend/domain/room/stat/service/RoomStatCreationTask.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/room/stat/service/RoomStatCreationTask.java
@@ -14,6 +14,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -31,7 +32,7 @@ public class RoomStatCreationTask implements Tasklet {
         List<Room> rooms = roomCrudServ.fetchAllRoom();
         // for each room
         for (Room room : rooms) {
-            LocalDate previousDate = LocalDate.now().minusDays(1);
+            LocalDate previousDate = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
             // create room stat
             RoomStat roomStat = RoomStat.builder()
                     .room(room)

--- a/src/main/java/com/sju/roomreservationbackend/domain/user/auth/entity/RefreshToken.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/user/auth/entity/RefreshToken.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Getter
 @Entity
@@ -42,8 +43,8 @@ public class RefreshToken {
         this.refreshToken = token;
         this.username = username;
         this.ipAddress = ipAddress;
-        this.issuedAt = LocalDateTime.now();
-        this.expiredAt = LocalDateTime.now().plusSeconds(JWTTokenProvider.JWT_REFRESH_TOKEN_VALIDITY);
+        this.issuedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.expiredAt = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusSeconds(JWTTokenProvider.JWT_REFRESH_TOKEN_VALIDITY);
         this.loggedOut = false;
     }
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/user/auth/services/UserAuthServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/user/auth/services/UserAuthServ.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Locale;
 
 @Service
@@ -49,7 +50,7 @@ public class UserAuthServ implements UserDetailsService, UserProfileServCommon {
         }
 
         // 마지막 로그인 일자 갱신
-        profile.setLastLoginAt(LocalDateTime.now());
+        profile.setLastLoginAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
 
         return profile;
     }
@@ -61,7 +62,7 @@ public class UserAuthServ implements UserDetailsService, UserProfileServCommon {
         // 기존에 유효한 리프레시 토큰이 있는지 확인
         // 유효함의 기준: username이 동일하고, 로그아웃되지 않았으며, 만료일이 미래인 토큰
         RefreshToken activeRefreshToken = refreshTokenRepo.findByUsernameAndLoggedOutAndExpiredAtGreaterThan(
-                profile.getUsername(), false, LocalDateTime.now()
+                profile.getUsername(), false, LocalDateTime.now(ZoneId.of("Asia/Seoul"))
         ).orElse(null);
 
         // 로그아웃 실시

--- a/src/main/java/com/sju/roomreservationbackend/domain/user/auth/services/UserTokenServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/user/auth/services/UserTokenServ.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Objects;
 
 @Service
@@ -38,7 +39,7 @@ public class UserTokenServ {
 
     public RefreshToken fetchActiveRefreshToken(UserProfile profile) {
         return refreshTokenRepo.findByUsernameAndLoggedOutAndExpiredAtGreaterThan(
-                profile.getUsername(), false, LocalDateTime.now()
+                profile.getUsername(), false, LocalDateTime.now(ZoneId.of("Asia/Seoul"))
         ).orElse(null);
     }
 

--- a/src/main/java/com/sju/roomreservationbackend/domain/user/profile/services/UserProfileCrudServ.java
+++ b/src/main/java/com/sju/roomreservationbackend/domain/user/profile/services/UserProfileCrudServ.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -46,7 +47,7 @@ public class UserProfileCrudServ extends UserProfileLogicServ implements UserPro
                 .noShowRate(0.0d)
                 .reserveCnt(0)
                 .noShowCnt(0)
-                .createdAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .permissions(perms)
                 .active(reqDTO.getPermission() == Permission.STUDENT)
                 .build();


### PR DESCRIPTION
## 개요
### PR 종류
**해당되는 한 가지만 선택하세요.**
 - [ ] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [x] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)
 - [ ] 소스코드 수정을 동반하지 않는 단순 문서 편집 (PR제목 양식: "[docs/브랜치명] 제목", 브랜치작명법: "docs/명칭" 사용)

### 작업내용
디바이스용 API에 대해 checkin code를 수신할 수 있게 함.

## 변경사항
 * device용 GET API에 한해 checkin code 필드 추가
 * LocalDateTime.now() 메소드 호출 시 (LocalDate, LocalTime 동일) 기본 시간대 UTC+9 설정 (버그 픽스)
 
## 비고
현재 iOT용 API 엔드포인트는 퍼블릭하게 열려있어 보안의 우려가 있긴 하나 추후에 별도 암호화 및 사용자 그룹 할당을 통한 인증 체계를 갖추는 것으로 하고, 패스. (현재로썬 구현소요가 큼)
